### PR TITLE
Filtering response based Ip of PRC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -864,7 +864,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1102,6 +1102,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
+name = "local-ip-address"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612ed4ea9ce5acfb5d26339302528a5e1e59dfed95e9e11af3c083236ff1d15d"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror 1.0.69",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1158,31 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-bigint"
@@ -1277,7 +1314,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1581,7 +1618,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1879,7 +1916,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-define-syscall",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2081,7 +2118,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2563,7 +2600,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-vote-interface",
- "thiserror",
+ "thiserror 2.0.12",
  "wasm-bindgen",
 ]
 
@@ -2791,7 +2828,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
- "thiserror",
+ "thiserror 2.0.12",
  "wasm-bindgen",
 ]
 
@@ -2843,7 +2880,7 @@ dependencies = [
  "borsh 1.5.5",
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3257,7 +3294,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3271,11 +3308,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3508,7 +3565,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3523,7 +3580,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3534,11 +3591,35 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3547,15 +3628,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3565,9 +3652,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3583,9 +3682,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3595,9 +3706,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3629,6 +3752,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
+ "local-ip-address",
  "log",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bincode = "1.3.3"
 solana-sdk = "2.2.1"
 prost = "0.13.5"
 serde = { version = "1.0", features = ["derive"] }
+local-ip-address = "0.5"
 
 [build-dependencies]
 prost-build = "0.13.5" 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,20 @@
 use log::{debug, error, info, warn};
 use logger::init_logger;
 use prost::Message;
+use protos::{Opcode, Request};
 use solana_sdk::{
     pubkey::Pubkey,
     sanitize::SanitizeError,
     transaction::{SanitizedVersionedTransaction, VersionedTransaction},
 };
-use std::{env, thread};
+use std::{env, net::IpAddr, thread};
 use std::{str::FromStr, thread::sleep, time::Duration};
-use types::{Opcode, Request};
+
+use crate::protos::{response::Response, ResponseWrapper};
+
 pub mod logger;
 
-mod types {
+mod protos {
     include!(concat!(env!("OUT_DIR"), "/_.rs"));
 }
 
@@ -79,6 +82,21 @@ fn main() {
     info!("Tcp Pull ip  : {}", tcp_pull_addr);
     info!("Tcp Push ip : {}", tcp_push_addr);
 
+    let ip = local_ip_address::local_ip().unwrap();
+
+    info!("ip address : {:?}", ip);
+
+    let mut ip_bytes = [0u8; 16];
+
+    match ip {
+        IpAddr::V4(v4) => {
+            ip_bytes[..4].copy_from_slice(&v4.octets());
+        }
+        IpAddr::V6(v6) => {
+            ip_bytes.copy_from_slice(&v6.octets());
+        }
+    }
+
     let context = zmq::Context::new();
 
     // Creating zmq sockets for the Back channel
@@ -102,7 +120,63 @@ fn main() {
                 Ok(msg) => {
                     debug!("Received Data from Atlas : {:?}", msg);
 
-                    match uds_push_socket.send(msg, 0) {
+                    // Extracting IP address from the Response buffer
+                    let (ip_prefix, req_bytes) = msg.split_at(16);
+                    let ip_address = if ip_prefix[4..] == [0; 12] {
+                        // It's IPv4
+                        IpAddr::V4(std::net::Ipv4Addr::new(
+                            ip_prefix[0],
+                            ip_prefix[1],
+                            ip_prefix[2],
+                            ip_prefix[3],
+                        ))
+                    } else {
+                        // It's IPv6
+                        let mut octets = [0u8; 16];
+                        octets.copy_from_slice(ip_prefix);
+                        IpAddr::V6(std::net::Ipv6Addr::from(octets))
+                    };
+
+                    // Checking if the The Response is for a RPC request or a transaction
+                    match ResponseWrapper::decode(req_bytes) {
+                        Ok(wrapper) => {
+                            let response = match wrapper.response {
+                                Some(ref resp) => resp.clone(),
+                                None => {
+                                    error!(
+                                        "Received empty Response in ResponseWrapper: id={}",
+                                        wrapper.id
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            match response.response {
+                                // If the response is for a RPC request and it is not originated from these docks/rpc
+                                // the it should be discarded.Since Each RPC will have their own Request counter
+                                // Request originated from other RPC will have different request number which could be
+                                // higher from this rpc. If the response for that request is stored in this rpc then
+                                // it will act as a poison response and it will provide false results in the future
+                                // for that request number
+                                Some(Response::Exists(_))
+                                | Some(Response::ListDir(_))
+                                | Some(Response::Metadata(_)) => {
+                                    if ip != ip_address {
+                                        info!("Received a RPC request originated from different RPC, discarding");
+                                        continue;
+                                    }
+                                }
+                                Some(Response::Tx(_)) => {}
+                                None => {}
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to decode ResponseWrapper: {:?}", e);
+                            debug!("Raw message: {:?}", msg);
+                        }
+                    }
+
+                    match uds_push_socket.send(req_bytes, 0) {
                         Ok(()) => debug!("Forwarded data from Atlas to UDS PUSH socket"),
                         Err(e) => error!("Failed to forward to UDS PUSH socket: {:?}", e),
                     }
@@ -132,7 +206,7 @@ fn main() {
             Ok(msg) => {
                 let reqs = deserialize_requests(msg);
 
-                info!("Request Received : {:?} ",reqs);
+                info!("Request Received : {:?} ", reqs);
 
                 if reqs.is_empty() {
                     warn!("No request Found, Skipping");
@@ -142,7 +216,17 @@ fn main() {
                     let mut buf = Vec::new();
                     req.encode(&mut buf).unwrap();
 
-                    let res = tcp_push_socket.send(&buf, 0);
+                    // Encoding first 16 bytes id buffer with Ipaddress so When it receives
+                    // Response from Atlas We Receive The IP.
+                    // This is needed For identifying RPC requests and their responses
+                    // If the RPC request is originated from These Docks/RPC Then and only then
+                    // It's response should be sent to the RPC else discarded
+
+                    let mut final_buf = Vec::with_capacity(16 + buf.len());
+                    final_buf.extend_from_slice(&ip_bytes);
+                    final_buf.extend_from_slice(&buf);
+
+                    let res = tcp_push_socket.send(&final_buf, 0);
 
                     match res {
                         Ok(()) => {


### PR DESCRIPTION
Filtering Response from Atlas with Ip address, Discarding the Response if the Ip Does not match .

Reason : 

 If the response is for a RPC request and it is not originated from these docks/rpc the it should be discarded.Since Each RPC will have their own Request counter. Request originated from other RPC will have different request number which could be higher from this rpc. If the response for that request is stored in this rpc then it will act as a poison response and it will provide false results in the future for that request number in this rpc